### PR TITLE
Actual: when click multiple times on "Get More" quickly, xapi stateme…

### DIFF
--- a/js/app/main.js
+++ b/js/app/main.js
@@ -170,6 +170,8 @@ define(function (require) {
 
       // Retreive statements from the LRS
       function getStatementsWithSearch(more, curPage) {
+        $("#more").attr("disabled", true);
+
         var verbSort = $("#search-verb-sort").val();
         var verbId = $("#search-user-verb-id").val();
         var actor = $("#search-actor").val();
@@ -251,6 +253,8 @@ define(function (require) {
               $('#statement-list').DataTable().page(curPage).draw(false);
               prettyPrint();
             }
+
+            $("#more").attr("disabled", false);
           });
         }
 


### PR DESCRIPTION
…nt viewer return in response the same statement.

Expected: return in response different statement every click on "Get More".

Solution: Disable "Get More" button during response is processing,